### PR TITLE
add option for save directory, fix DESKTOP_SESSION bug

### DIFF
--- a/wanda/wanda.py
+++ b/wanda/wanda.py
@@ -68,7 +68,7 @@ def set_wp(url: str, folder: str, home=True, lock=True, fitwp=False):
         exit(1)
 
 
-def get_dl_path():
+def get_dl_path(folder):
     path = os.path.normpath(f"{folder}/wanda_{int(time.time())}")
     if not os.path.exists(folder):
         os.mkdir(folder)
@@ -740,7 +740,7 @@ def run():
         if source != "local" and not is_connected():
             print("Please check your internet connection and try again")
             exit(1)
-        set_wp(eval(source_map(source))(term), home, lock, fitwp)
+        set_wp(eval(source_map(source))(term), folder, home, lock, fitwp)
     except NameError:
         print(f"Unknown source: '{source}'. Available sources:")
         usage()


### PR DESCRIPTION
add -w option for setting working directory where images are saved so the home directory isn't affected. With this change I think it makes sense to not run the empty_download_folder function, since this may unexpectedly remove more than the user intends

On systems where DESKTOP_SESSION is not defined, code would hit an error when trying to run .lower() on None. Added case to catch this problem.